### PR TITLE
Add package name

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,4 +1,5 @@
 Package.describe({
+  name: "patrickleet:tags",
   summary: "Add groups of tags to selected collections",
   version: "1.0.1",
   git: "https://github.com/patrickleet/tags"


### PR DESCRIPTION
I know it is not required but forking this repo and installing it locally will be much easier if the package has a name.

Here is the workflow I am talking about:
https://github.com/EventedMind/iron-router#working-locally
